### PR TITLE
メールマガジンプラグインFixerの修正。

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,21 @@ docker run --rm -v /path/to/plugin:/app eccube/upgrade-fixer fix /app
 
 ## 利用可能なFixer一覧
 
-| Name  | Description |
-| ----  | ----------- |
-| app_request | Fix $app["request"] -> $app["request"]->getCurrentRequest(). |
-| eccube_form_type_names | EC-CUBE FormType support. |
-| form_choice_type_array | Flip choices in ChoiceType. |
-| form_configure_options | The method AbstractType::setDefaultOptions(OptionsResolverInterface $resolver) have been renamed to AbstractType::configureOptions(OptionsResolver $resolver). |
-| form_events | The events PRE_BIND, BIND and POST_BIND were renamed to PRE_SUBMIT, SUBMIT and POST_SUBMIT. |
-| form_getname_to_getblockprefix | The method FormTypeInterface::getName() was deprecated, you should now implement FormTypeInterface::getBlockPrefix() instead. |
-| form_option_names | Options precision and virtual was renamed to scale and inherit_data. |
-| form_parent_type | Returning type instances from FormTypeInterface::getParent() is deprecated, return the fully-qualified class name of the parent type class instead. |
-| form_type_names | Instead of referencing types by name, you should reference them by their fully-qualified class name (FQCN) instead. |
-| get_request | The getRequest method of the base controller class was removed, request object is injected in the action method instead. |
-| inherit_data_aware_iterator | The class VirtualFormAwareIterator was renamed to InheritDataAwareIterator. |
-| progress_bar | ProgressHelper has been removed in favor of ProgressBar. |
-| property_access | Renamed PropertyAccess::getPropertyAccessor to PropertyAccess::createPropertyAccessor. |
-| service_provider | Fix ServiceProvider. |
+| Name                             | Description                                                                                 |
+|----------------------------------|---------------------------------------------------------------------------------------------|
+| doctrine_namespace               | Update Doctrine namespacing                                                                 |
+| email_validator                  | Fix up strict validation changes to email. From an instance reference to CONSTANT reference |
+| email_validator_parameter_update | Email validation parameter updated                                                          |
+| event_dispatcher                 | Switch EC-CUBE Event dispatcher parameters                                                  |
+| event_namespace_update           | Response event namespace update.                                                            |
+| extended_types_type_return       | Add iterable type return to getExtendedTypes() class                                        |
+| pDOFunction_update               | fetchOne to fetchRow Update                                                                 |
+| pHP8_parameter                   | Fixes for php 8                                                                             |
+| pHPDOC                           | Fixes to incorrect php doc class references                                                 |
+| remove_format_from_date_form     | Remove date parameter from DateType::class                                                  |
+| swift_mailer_change              | Update from \Swift_Mailer to Symfony 5 MailerInterface                                      |
+| translation_class                | Translation class fixes                                                                     |
+| unit_test                        | UnitTest setUp function requires void return type                                           |
 
 
 ## Contribute

--- a/src/Symfony/Upgrade/Fixer/PHP8ParameterFixer.php
+++ b/src/Symfony/Upgrade/Fixer/PHP8ParameterFixer.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Symfony\Upgrade\Fixer;
+
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+use UnexpectedValueException;
+
+class PHP8ParameterFixer extends AbstractFixer
+{
+    /**
+     * @inheritDoc
+     */
+    public function fix(\SplFileInfo $file, $content): string
+    {
+        $tokens = Tokens::fromCode($content);
+        $this->_removeShift_MailerFromIndexFunc($tokens);
+        return $tokens->generateCode();
+    }
+
+    /**
+     * メールマガジンプラグインで、オプションのパラメータよりも無効な必須パラメータが存在する場合の特殊な例です。
+     * Special instance for mail magazine plugin where invalid required parameter exists over optional parameter
+     * @param Tokens|Token[] $tokens
+     * @return void
+     */
+    private function _removeShift_MailerFromIndexFunc(Tokens $tokens, int $index = 0) {
+        $findSwiftMailerInstanceToken = $tokens->findSequence([
+            [T_PUBLIC],
+            [T_FUNCTION],
+            [T_STRING, 'index'],
+            '('
+        ], $index);
+        
+        if ($findSwiftMailerInstanceToken === null) {
+            return;
+        }
+
+        $useTokenIndexes = array_keys($findSwiftMailerInstanceToken);
+        try {
+            $blockEndToken = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, end($useTokenIndexes), true);
+        } catch (UnexpectedValueException $exception) {
+            // @todo : ここに不正な構文の警告を追加する。
+            // @todo: Add Bad syntax warning here.
+            $this->_removeShift_MailerFromIndexFunc($tokens, end($useTokenIndexes));
+            return;
+        }
+        
+        $targetID = -1;
+        for($i = $useTokenIndexes[0]; $i < $blockEndToken; $i++) {
+            if($tokens[$i]->getContent() === 'Swift_Mailer') {
+                $targetID = $i;
+                break;
+            }
+        }
+        if ($targetID == -1) {
+            $this->_removeShift_MailerFromIndexFunc($tokens, end($useTokenIndexes));
+            return;
+        }
+        
+        $xx = 0;
+        while(true) {
+            $xx++;
+            if($tokens[$targetID - $xx]->getContent() === ',') {
+                $tokens[$targetID - $xx]->setContent('');
+                break;
+            }
+            $tokens[$targetID - $xx]->setContent('');
+        }
+        $xx = 0;
+        while(true) {
+            $xx++;
+            if($tokens[$targetID + $xx]->getContent() === ')') {
+                break;
+            }
+            $tokens[$targetID + $xx]->setContent('');
+        }
+        $tokens[$targetID]->setContent('');
+        $this->_removeShift_MailerFromIndexFunc($tokens, $blockEndToken);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDescription(): string
+    {
+        return "Fixes for php 8";
+    }
+}

--- a/src/Symfony/Upgrade/Fixer/PHPDOCFixer.php
+++ b/src/Symfony/Upgrade/Fixer/PHPDOCFixer.php
@@ -20,7 +20,6 @@ class PHPDOCFixer extends AbstractFixer
     }
 
     private function _phpDocClassReferenceFix(string &$fileContent, string $phpDocType, string $classReferenceName, string $replaceReferenceName, ?string $variableIdentifier = null) {
-//        var_dump(sprintf("@%s %s", $phpDocType, $classReferenceName));
         if($variableIdentifier == null) {
             $fileContent = str_replace(sprintf("@%s %s", $phpDocType, $classReferenceName), sprintf("@%s %s", $phpDocType, $replaceReferenceName), $fileContent);
         }

--- a/src/Symfony/Upgrade/Fixer/RenameFixer.php
+++ b/src/Symfony/Upgrade/Fixer/RenameFixer.php
@@ -116,6 +116,32 @@ abstract class RenameFixer extends AbstractFixer
         $this->renameChainMethods($tokens, $old, $new, end($useTokenIndexes));
     }
 
+    /**
+     * @param Tokens|Token[] $tokens
+     * @param string $keyName
+     * @param string $associatedKey // TODO: Use Enclosed match type search to prevent mismatch code
+     * @param int $oldValueTokenType
+     * @param $oldValue
+     * @param $newValue
+     * @param int $index
+     * @return void
+     */
+    protected function renameArrayValue(Tokens $tokens, string $keyName, string $associatedKey, int $oldValueTokenType, $oldValue, $newValue, int $index = 0) {
+        $arrayValueKeyTokens = $tokens->findSequence([
+            [T_CONSTANT_ENCAPSED_STRING, $keyName],
+            [T_DOUBLE_ARROW, '=>'],
+            [T_STRING, $oldValue]
+        ], $index);
+
+        if ($arrayValueKeyTokens == null) {
+            return;
+        }
+
+        $arrayValueKeyTokenKeys = array_keys($arrayValueKeyTokens);
+        $tokens[end($arrayValueKeyTokenKeys)]->setContent($newValue);
+        $this->renameArrayValue($tokens, $keyName, $associatedKey, $oldValueTokenType, $oldValue, $newValue, end($arrayValueKeyTokenKeys));
+    }
+
 
     protected function renameFunctionParameterTypes(Tokens &$tokens, string $old, string $new, int $index = 0)
     {

--- a/src/Symfony/Upgrade/Fixer/ReturnTypeFixer.php
+++ b/src/Symfony/Upgrade/Fixer/ReturnTypeFixer.php
@@ -23,16 +23,9 @@ abstract class ReturnTypeFixer extends RenameFixer
         if ($matchedTokens == null) {
             return;
         }
-
-//        var_dump($matchedTokens);
+        
         $useTokenIndexes = array_keys($matchedTokens);
-
-        if ($returnType == 'iterable') {
-//            var_dump($tokens[end($useTokenIndexes) + 1]);
-//            var_dump($tokens[end($useTokenIndexes) + 2]);
-//            var_dump($tokens[end($useTokenIndexes) + 3]);
-//            var_dump($tokens[end($useTokenIndexes) + 4]);
-        }
+        
 
         $isExistsAlready = false;
 

--- a/src/Symfony/Upgrade/Fixer/UnitTestFixer.php
+++ b/src/Symfony/Upgrade/Fixer/UnitTestFixer.php
@@ -43,7 +43,6 @@ class UnitTestFixer extends ReturnTypeFixer
         // Login process UT update
         $this->_UTLoginProcessUpdate($tokens);
         
-//        var_dump(T_STRING);
         $this->renameArrayValue($tokens, '\'tags\'', '', T_STRING,"null", "[]");
         $this->renameArrayValue($tokens, '\'images\'', '', T_STRING, "null", "[]");
         $this->renameArrayValue($tokens, '\'add_images\'', '', T_STRING , "null", "[]");
@@ -72,13 +71,10 @@ class UnitTestFixer extends ReturnTypeFixer
         );
 
         if ($mailCollectorTokens == null) {
-//            var_dump("NOPE");
             return;
         }
 
         $matchedIndexes = array_keys($mailCollectorTokens);
-//        var_dump("YEP");
-//        var_dump($matchedIndexes);
 
         // Get Previous token which *should* be the variable name (or the plugin itself would crash)
         $mailCollectorName = $tokens[$matchedIndexes[0] - 2]->getContent();
@@ -103,14 +99,11 @@ class UnitTestFixer extends ReturnTypeFixer
         ], $index);
 
         if ($secondLineTokens == null) {
-//            var_dump("STOP1");
             $this->_getMailCollectorToGetMailerMessage($tokens, $endToken);
             return;
         }
 
         $matchedIndexes = array_keys($secondLineTokens);
-//        var_dump("YEP2");
-//        var_dump($matchedIndexes);
 
         // Get Previous token which *should* be the variable name (or the plugin itself would crash)
         $secondLineVariableName = $tokens[$matchedIndexes[0] - 2]->getContent();
@@ -134,8 +127,6 @@ class UnitTestFixer extends ReturnTypeFixer
         }
 
         $matchedIndexes = array_keys($thirdLineReplaceLine);
-//        var_dump("YEP3");
-//        var_dump($matchedIndexes);
 
         $i = 0;
         while (true) {

--- a/src/Symfony/Upgrade/Fixer/UnitTestFixer.php
+++ b/src/Symfony/Upgrade/Fixer/UnitTestFixer.php
@@ -42,7 +42,14 @@ class UnitTestFixer extends ReturnTypeFixer
         $this->_getMailCollectorToGetMailerMessage($tokens);
         // Login process UT update
         $this->_UTLoginProcessUpdate($tokens);
-
+        
+//        var_dump(T_STRING);
+        $this->renameArrayValue($tokens, '\'tags\'', '', T_STRING,"null", "[]");
+        $this->renameArrayValue($tokens, '\'images\'', '', T_STRING, "null", "[]");
+        $this->renameArrayValue($tokens, '\'add_images\'', '', T_STRING , "null", "[]");
+        $this->renameArrayValue($tokens, '\'delete_images\'', '', T_STRING, "null", "[]");
+        $this->renameArrayValue($tokens, '\'Category\'', '', T_STRING, "null", "[]");
+        
         return $tokens->generateCode();
     }
 
@@ -186,9 +193,6 @@ class UnitTestFixer extends ReturnTypeFixer
         }
 
         $matchedIndexes = array_keys($difficultFind);
-//        var_dump($tokens[end($matchedIndexes)]->getContent());
-//        var_dump($tokens[end($matchedIndexes) + 1]->getContent());
-//        var_dump($tokens[end($matchedIndexes) + 1]->getPrototype());
 
         // FindSequence functionality had trouble finding strings so find strings using another way
         if ($tokens[end($matchedIndexes) + 1]->getContent() !== "'security.token_storage'") {


### PR DESCRIPTION
2点の修正が必要でした。

① \Swift_MailerクラスのsetTo関数のパラメータは配列でしたが、今回Emailクラスのto関数のパラメータは文字列のみです。
なので、toのパラメータを文字列に変換するように修正しました。

例えば：
```
(new \Swift_Message())
->setTo([$formData['email']])
```
から
```
(new Email())
->to($formData['email'])　// 角括弧がなくなりました。
```
に変換。

② 任意パラメータの右に必須パラメータはPHP8で禁止されていますので、エラーが発生しないように、メールマガジンプラグイン4.nと同じ修正で\Swift_Mailerパラメータを削除する。

例えば：
```
public function index(Request $request, PaginatorInterface $paginator, $page_no = null, \Swift_Mailer $mailer)
```
↓             
```
public function index(Request $request, PaginatorInterface $paginator, $page_no = null)
```
に変換。


